### PR TITLE
Error on MacOs upon opening a branch :  this fix "spawn ENOENT" by resolving full claude CLI path and handle missing cwd

### DIFF
--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,32 +1,63 @@
 import { spawn, execFileSync } from 'node:child_process';
-import { openSync, closeSync } from 'node:fs';
+import { openSync, closeSync, accessSync } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
 /**
+ * Resolve the full absolute path of `claude` via the shell's `command -v`.
+ * Returns undefined if resolution fails.
+ */
+function resolveFullPath(name: string): string | undefined {
+  try {
+    return execFileSync('/bin/sh', ['-c', `command -v ${name}`], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Find the claude CLI executable path.
- * On Windows, resolves to the full path to avoid needing shell: true.
+ * Always resolves to a full absolute path when possible, because
+ * spawn() without shell:true can fail to find bare command names
+ * when called with a different cwd.
  */
 export function getClaudeCliPath(configPath?: string): string {
   if (configPath) return configPath;
 
-  if (process.platform === 'win32') {
-    // Try common Windows locations
-    const candidates = [
-      path.join(os.homedir(), '.local', 'bin', 'claude.exe'),
-      'claude.exe',
-    ];
+  // Try bare name first — resolve to full path to avoid spawn() issues
+  try {
+    execFileSync('claude', ['--version'], { stdio: 'ignore' });
+    // Bare name works, but resolve the full path for robustness
+    const fullPath = resolveFullPath('claude');
+    return fullPath || 'claude';
+  } catch {
+    // Not found via PATH — try known locations
+  }
 
-    for (const candidate of candidates) {
-      try {
-        execFileSync(candidate, ['--version'], { stdio: 'ignore' });
-        return candidate;
-      } catch {
-        // Try next
-      }
+  const candidates = process.platform === 'win32'
+    ? [
+        path.join(os.homedir(), '.local', 'bin', 'claude.exe'),
+        'claude.exe',
+      ]
+    : [
+        path.join(os.homedir(), '.local', 'bin', 'claude'),
+        '/usr/local/bin/claude',
+        '/opt/homebrew/bin/claude',
+      ];
+
+  for (const candidate of candidates) {
+    try {
+      execFileSync(candidate, ['--version'], { stdio: 'ignore' });
+      return candidate;
+    } catch {
+      // Try next
     }
   }
 
+  // Last resort: return bare name and let spawn() fail with a clear error
   return 'claude';
 }
 
@@ -39,6 +70,18 @@ export function getClaudeCliPath(configPath?: string): string {
 export function spawnClaudeInteractive(args: string[], cliPath?: string, cwd?: string): Promise<number | null> {
   return new Promise((resolve, reject) => {
     const cmd = getClaudeCliPath(cliPath);
+
+    // Validate cwd exists — spawn() throws a confusing ENOENT
+    // (with the command name, not the directory) when cwd is invalid.
+    // Fall back to current directory so the session can still be resumed.
+    let effectiveCwd = cwd;
+    if (effectiveCwd) {
+      try {
+        accessSync(effectiveCwd);
+      } catch {
+        effectiveCwd = undefined; // fall back to process.cwd()
+      }
+    }
 
     // On Windows, if stdin has been destroyed (e.g. after Ink TUI teardown),
     // stdio: 'inherit' fails because the underlying console handle was closed.
@@ -58,7 +101,7 @@ export function spawnClaudeInteractive(args: string[], cliPath?: string, cwd?: s
 
     const child = spawn(cmd, args, {
       stdio,
-      ...(cwd ? { cwd } : {}),
+      ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
     });
 
     const cleanup = () => {


### PR DESCRIPTION
The spawn ENOENT error had two causes: (1) spawn() without shell:true couldn't find bare 'claude' in some contexts, and (2) spawn() throws the same ENOENT when the cwd directory doesn't exist, making the error misleading. Now resolves claude to its full absolute path via `command -v`, and gracefully falls back to process.cwd() when the stored project directory no longer exists.