### PR TITLE
fix: use absolute path for cmv binary in hook commands

### DIFF
--- a/src/commands/hook.ts
+++ b/src/commands/hook.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Command } from 'commander';
 import * as fs from 'node:fs/promises';
-import { getClaudeSettingsPath, getCmvAutoTrimLogPath } from '../utils/paths.js';
+import { getClaudeSettingsPath, getCmvAutoTrimLogPath, resolveCmvBinary } from '../utils/paths.js';
 import { listBackups, restoreBackup } from '../core/auto-backup.js';
 import { success, info, dim } from '../utils/display.js';
 import { handleError } from '../utils/errors.js';
@@ -20,15 +20,13 @@ interface ClaudeSettings {
   [key: string]: unknown;
 }
 
-const CMV_COMMAND_PREFIX = 'cmv auto-trim';
-
-function buildHookConfig(): Record<string, Array<{ matcher: string; hooks: Array<{ type: string; command: string; timeout: number }> }>> {
+function buildHookConfig(cmvBin: string): Record<string, Array<{ matcher: string; hooks: Array<{ type: string; command: string; timeout: number }> }>> {
   return {
     PreCompact: [{
       matcher: '',
       hooks: [{
         type: 'command',
-        command: 'cmv auto-trim',
+        command: `${cmvBin} auto-trim`,
         timeout: 30,
       }],
     }],
@@ -36,7 +34,7 @@ function buildHookConfig(): Record<string, Array<{ matcher: string; hooks: Array
       matcher: '',
       hooks: [{
         type: 'command',
-        command: 'cmv auto-trim --check-size',
+        command: `${cmvBin} auto-trim --check-size`,
         timeout: 10,
       }],
     }],
@@ -58,8 +56,11 @@ async function writeSettings(settings: ClaudeSettings): Promise<void> {
   await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
 }
 
+/**
+ * Matches both bare `cmv auto-trim` (old installs) and absolute-path variants.
+ */
 function isCmvHookEntry(entry: { matcher: string; hooks: Array<{ command: string }> }): boolean {
-  return entry.hooks.some(h => h.command.startsWith(CMV_COMMAND_PREFIX));
+  return entry.hooks.some(h => /(?:^|[\\/])cmv(?:\.cmd|\.ps1)?\s+auto-trim/.test(h.command));
 }
 
 function formatSize(bytes: number): string {
@@ -80,7 +81,8 @@ export function registerHookCommand(program: Command): void {
         const settings = await readSettings();
         if (!settings.hooks) settings.hooks = {};
 
-        const newHooks = buildHookConfig();
+        const cmvBin = await resolveCmvBinary();
+        const newHooks = buildHookConfig(cmvBin);
 
         for (const [event, entries] of Object.entries(newHooks)) {
           if (!settings.hooks[event]) {

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -6,9 +6,7 @@
  * Runs silently — failures are swallowed so npm install never breaks.
  */
 import * as fs from 'node:fs/promises';
-import { getClaudeSettingsPath } from './utils/paths.js';
-
-const CMV_COMMAND_PREFIX = 'cmv auto-trim';
+import { getClaudeSettingsPath, resolveCmvBinary } from './utils/paths.js';
 
 interface ClaudeSettings {
   hooks?: Record<string, Array<{
@@ -22,13 +20,13 @@ interface ClaudeSettings {
   [key: string]: unknown;
 }
 
-function buildHookConfig() {
+function buildHookConfig(cmvBin: string) {
   return {
     PreCompact: [{
       matcher: '',
       hooks: [{
         type: 'command',
-        command: 'cmv auto-trim',
+        command: `${cmvBin} auto-trim`,
         timeout: 30,
       }],
     }],
@@ -36,15 +34,18 @@ function buildHookConfig() {
       matcher: '',
       hooks: [{
         type: 'command',
-        command: 'cmv auto-trim --check-size',
+        command: `${cmvBin} auto-trim --check-size`,
         timeout: 10,
       }],
     }],
   };
 }
 
+/**
+ * Matches both bare `cmv auto-trim` (old installs) and absolute-path variants.
+ */
 function isCmvHookEntry(entry: { hooks: Array<{ command: string }> }): boolean {
-  return entry.hooks.some(h => h.command.startsWith(CMV_COMMAND_PREFIX));
+  return entry.hooks.some(h => /(?:^|[\\/])cmv(?:\.cmd|\.ps1)?\s+auto-trim/.test(h.command));
 }
 
 async function main() {
@@ -60,14 +61,10 @@ async function main() {
 
   if (!settings.hooks) settings.hooks = {};
 
-  // Check if already installed
-  const alreadyInstalled =
-    settings.hooks.PreCompact?.some(e => isCmvHookEntry(e)) &&
-    settings.hooks.PostToolUse?.some(e => isCmvHookEntry(e));
+  const cmvBin = await resolveCmvBinary();
 
-  if (alreadyInstalled) return;
-
-  const newHooks = buildHookConfig();
+  // Always replace hooks to ensure the path is up-to-date
+  const newHooks = buildHookConfig(cmvBin);
 
   for (const [event, entries] of Object.entries(newHooks)) {
     if (!settings.hooks[event]) {
@@ -78,7 +75,7 @@ async function main() {
   }
 
   await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
-  console.log('CMV: auto-trim hooks installed into Claude Code settings.');
+  console.log(`CMV: auto-trim hooks installed (binary: ${cmvBin}).`);
 }
 
 export { main, buildHookConfig, isCmvHookEntry };

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -103,3 +103,60 @@ export function getCmvAutoTrimLogPath(): string {
 export function getClaudeSettingsPath(): string {
   return path.join(getClaudeBaseDir(), 'settings.json');
 }
+
+/**
+ * Resolve the absolute path to the cmv binary for use in hook commands.
+ *
+ * Claude Code hooks run in non-interactive shells that don't source .bashrc,
+ * so custom PATH entries (like ~/.npm-global/bin) aren't available. Using an
+ * absolute path ensures the hook works regardless of shell configuration.
+ *
+ * Resolution order:
+ *   1. Walk up from this file to find the package's dist/index.js
+ *   2. Fall back to `which cmv` / `where cmv`
+ *   3. Fall back to bare `cmv` (original behavior) if nothing else works
+ */
+export async function resolveCmvBinary(): Promise<string> {
+  // Strategy 1: This file is at <pkg>/dist/utils/paths.js at runtime.
+  // Walk up to find package.json, then use dist/index.js.
+  try {
+    let dir = path.dirname(new URL(import.meta.url).pathname);
+    // On Windows, strip leading slash from /C:/... paths
+    if (process.platform === 'win32' && dir.match(/^\/[A-Za-z]:\//)) {
+      dir = dir.slice(1);
+    }
+    for (let i = 0; i < 5; i++) {
+      const pkgJson = path.join(dir, 'package.json');
+      try {
+        await fs.access(pkgJson);
+        const entryPoint = path.join(dir, 'dist', 'index.js');
+        await fs.access(entryPoint);
+        return entryPoint;
+      } catch {
+        dir = path.dirname(dir);
+      }
+    }
+  } catch {
+    // import.meta.url resolution failed, continue to next strategy
+  }
+
+  // Strategy 2: Use `which` (Unix) or `where` (Windows) to find cmv on PATH
+  try {
+    const { execFileSync } = await import('node:child_process');
+    const cmd = process.platform === 'win32' ? 'where' : 'which';
+    const result = execFileSync(cmd, ['cmv'], { encoding: 'utf-8', timeout: 5000 }).trim();
+    // `where` on Windows can return multiple lines; take the first
+    const firstLine = result.split('\n')[0]!.trim();
+    if (firstLine) {
+      // Resolve symlinks to get the real path
+      const resolved = await fs.realpath(firstLine);
+      return resolved;
+    }
+  } catch {
+    // cmv not on PATH, continue to fallback
+  }
+
+  // Strategy 3: bare command (original behavior, will fail in non-interactive shells
+  // but is no worse than before)
+  return 'cmv';
+}


### PR DESCRIPTION
Hi Cosmo,

First of all thank you very much for creating this repo. I used it with proper attribution in this Medium article: https://medium.com/@med25_4356/my-claude-is-better-than-your-claude-4242c4040da5

You may want to have a look at the article and incorporate some of the other things in it. In any case I found a small issue when I used your repo, so I thought it best to send you a PR. Our buddy Claude wrote the rest of this, but I wanted to say hi, and thanks again.

-Bob

---

## Summary

Hook commands currently use bare `cmv`, which fails in non-interactive shells (Claude Code hooks) where custom PATH entries from `.bashrc` aren't loaded. This resolves the absolute path at install time instead.

Fixes the `PostToolUse:Write hook error` that Linux users see on every tool call.

## Changes

- **`src/utils/paths.ts`**: New `resolveCmvBinary()` with three resolution strategies (walk up from script, which/where fallback, bare command fallback)
- **`src/postinstall.ts`**: `buildHookConfig()` takes resolved path; `isCmvHookEntry()` matches both old and new formats; removed early-return so re-running updates the path
- **`src/commands/hook.ts`**: Same changes to `buildHookConfig()` and `isCmvHookEntry()`

## Reproduction

1. Install CMV per the README on Linux (`npm link`)
2. Confirm `cmv --version` works in an interactive terminal
3. Start a Claude Code session and use any tool
4. Observe `PostToolUse hook error` in the output

Confirm with:
```bash
env -i HOME=$HOME PATH=/usr/bin:/bin cmv auto-trim --check-size
# => env: 'cmv': No such file or directory
```

## Result

Hooks now write absolute paths into settings.json:
```json
"command": "/home/user/.claude-plugins/cmv/dist/index.js auto-trim --check-size"
```

Backwards compatible. Existing users re-run `npm run build && node dist/postinstall.js` to fix their hooks.