### PR TITLE
fix(trimmer): preserve prompt field from broad-fallback stubbing

### DIFF
--- a/src/core/trimmer.ts
+++ b/src/core/trimmer.ts
@@ -34,6 +34,12 @@ const PRESERVED_INPUT_FIELDS = new Set([
   'edit_mode',
   'cell_type',
   'cell_id',
+  // Agent/Task dispatch prompt — subagents receive this verbatim as their
+  // instructions. Stubbing it means dispatched agents get
+  // "[Trimmed input: ~N chars]" instead of the real task, which is
+  // catastrophic for subagent behaviour. It is frequently >500 chars so it
+  // trips the broad-fallback without explicit preservation.
+  'prompt',
 ]);
 
 /**

--- a/tests/trimmer.test.ts
+++ b/tests/trimmer.test.ts
@@ -190,6 +190,31 @@ describe('trimmer', () => {
     });
 
     it('preserves identification fields in broad fallback', async () => {
+      // Use a non-preserved string field (extra) to force a stubbing pass so
+      // the metric increments and we can assert preserved fields come through
+      // untouched.
+      const bigExtra = 'z'.repeat(600);
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'assistant', content: [{
+          type: 'tool_use', id: 't1', name: 'CustomTool',
+          input: { description: 'do stuff', extra: bigExtra }
+        }] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest);
+      const output = await readJsonl(dest);
+
+      expect(metrics.toolUseInputsStubbed).toBe(1);
+      const input = output[0].content[0].input;
+      expect(input.description).toBe('do stuff');
+      expect(input.extra).toContain('[Trimmed input');
+    });
+
+    it('preserves Task/Agent prompt field even when over threshold', async () => {
+      // The Agent/Task tool input's `prompt` field carries the dispatched
+      // subagent's instructions verbatim. Stubbing it would hand the subagent
+      // "[Trimmed input: ~N chars]" instead of a real task.
       const bigPrompt = 'z'.repeat(600);
       const src = await writeJsonl('src.jsonl', [
         { type: 'assistant', content: [{
@@ -202,10 +227,11 @@ describe('trimmer', () => {
       const metrics = await trimJsonl(src, dest);
       const output = await readJsonl(dest);
 
-      expect(metrics.toolUseInputsStubbed).toBe(1);
+      // No non-preserved string field is large enough to stub — metric stays 0.
+      expect(metrics.toolUseInputsStubbed).toBe(0);
       const input = output[0].content[0].input;
       expect(input.description).toBe('do stuff');
-      expect(input.prompt).toContain('[Trimmed input');
+      expect(input.prompt).toBe(bigPrompt);
     });
 
     it('does not stub small tool_use inputs', async () => {


### PR DESCRIPTION
## Summary

The Agent/Task tool's input contains a `prompt` string that carries the dispatched subagent's instructions verbatim. It is frequently well over the default 500-char stub threshold, so the broad-fallback stubbing in `stubToolUseInput` replaces it with `[Trimmed input: ~N chars]`. When the jsonl is then reused as transcript context (e.g. after auto-trim), any subagent re-dispatched from that turn receives the stub instead of the real task, which is catastrophic for subagent behaviour.

Add `'prompt'` to `PRESERVED_INPUT_FIELDS` so it is exempt from stubbing, alongside the other identification / metadata fields (`file_path`, `command`, `description`, `url`, etc.).

## Changes

- `src/core/trimmer.ts`: add `'prompt'` to `PRESERVED_INPUT_FIELDS` with a comment explaining why.
- `tests/trimmer.test.ts`:
  - Update the existing "preserves identification fields in broad fallback" test to use a non-preserved field name (`extra`) as its large value, since it incidentally used `prompt` and asserted it got stubbed.
  - Add a new dedicated test "preserves Task/Agent prompt field even when over threshold" asserting the Task `prompt` input stays verbatim when over threshold.

## Test plan

- [x] `npm run test:run` — 466 passed (up from 465; +1 new test)
- [x] `npm run build` — clean TypeScript compile
- [x] Existing test for Write/Edit tool content/old_string/new_string stubbing still passes
- [x] New test asserts `prompt` passes through unchanged on a Task tool_use block with a 600-char prompt