### PR TITLE
feat(trimmer): add keepLast option to leave last N entries untouched

### DIFF
--- a/src/commands/auto-trim.ts
+++ b/src/commands/auto-trim.ts
@@ -80,7 +80,8 @@ export function registerAutoTrimCommand(program: Command): void {
     .command('auto-trim')
     .description('Internal command called by Claude Code hooks')
     .option('--check-size', 'Only trim if file exceeds size threshold (PostToolUse mode)')
-    .action(async (opts: { checkSize?: boolean }) => {
+    .option('--keep-last <n>', 'Leave the last N non-empty jsonl entries fully unmodified (overrides autoTrim.keepLast config)')
+    .action(async (opts: { checkSize?: boolean; keepLast?: string }) => {
       try {
         const stdinRaw = await readStdinWithTimeout(STDIN_TIMEOUT);
         const input: HookInput = JSON.parse(stdinRaw);
@@ -115,8 +116,10 @@ export function registerAutoTrimCommand(program: Command): void {
 
         // Trim in-place via temp file
         const tmpPath = transcriptPath + '.cmv-trim-tmp';
+        const keepLastOverride = opts.keepLast !== undefined ? parseInt(opts.keepLast, 10) : undefined;
         const metrics = await trimJsonl(transcriptPath, tmpPath, {
           threshold: config.threshold ?? DEFAULT_TRIM_THRESHOLD,
+          keepLast: keepLastOverride ?? config.keepLast,
         });
 
         // Atomic replace

--- a/src/commands/branch.ts
+++ b/src/commands/branch.ts
@@ -36,9 +36,10 @@ export function registerBranchCommand(program: Command): void {
     .option('-n, --name <name>', 'Name for the branch')
     .option('--no-trim', 'Skip trimming (copies raw context)')
     .option('-t, --threshold <chars>', 'Stub threshold when trimming (default: 500)')
+    .option('--keep-last <n>', 'Leave the last N non-empty jsonl entries fully unmodified when trimming (default: 20, 0 to disable)')
     .option('--skip-launch', "Don't launch Claude Code, just create the session file")
     .option('--dry-run', 'Show what would happen without doing it')
-    .action(async (snapshotName: string, opts: { name?: string; trim: boolean; threshold?: string; skipLaunch?: boolean; dryRun?: boolean }) => {
+    .action(async (snapshotName: string, opts: { name?: string; trim: boolean; threshold?: string; keepLast?: string; skipLaunch?: boolean; dryRun?: boolean }) => {
       try {
         const result = await createBranch({
           snapshotName,
@@ -47,6 +48,7 @@ export function registerBranchCommand(program: Command): void {
           dryRun: opts.dryRun,
           trim: opts.trim,
           trimThreshold: opts.threshold ? parseInt(opts.threshold, 10) : undefined,
+          trimKeepLast: opts.keepLast !== undefined ? parseInt(opts.keepLast, 10) : undefined,
         });
 
         if (opts.dryRun) {

--- a/src/commands/trim.ts
+++ b/src/commands/trim.ts
@@ -20,7 +20,8 @@ export function registerTrimCommand(program: Command): void {
     .option('-n, --name <name>', 'Name for the snapshot')
     .option('--skip-launch', "Don't launch Claude Code after trimming")
     .option('-t, --threshold <chars>', 'Stub threshold in characters (default: 500)')
-    .action(async (opts: { session?: string; latest?: boolean; name?: string; skipLaunch?: boolean; threshold?: string }) => {
+    .option('--keep-last <n>', 'Leave the last N non-empty jsonl entries fully unmodified (default: 20, 0 to disable)')
+    .action(async (opts: { session?: string; latest?: boolean; name?: string; skipLaunch?: boolean; threshold?: string; keepLast?: string }) => {
       try {
         if (!opts.session && !opts.latest) {
           console.error('Must provide --session <id> or --latest');
@@ -49,6 +50,7 @@ export function registerTrimCommand(program: Command): void {
           trim: true,
           noLaunch: opts.skipLaunch,
           trimThreshold: opts.threshold ? parseInt(opts.threshold, 10) : undefined,
+          trimKeepLast: opts.keepLast !== undefined ? parseInt(opts.keepLast, 10) : undefined,
         });
 
         success(`Trimmed branch "${result.branchName}" created.`);

--- a/src/core/branch-manager.ts
+++ b/src/core/branch-manager.ts
@@ -16,6 +16,8 @@ export interface BranchParams {
   dryRun?: boolean;
   trim?: boolean;
   trimThreshold?: number;
+  /** Number of trailing entries to leave untouched when trimming. */
+  trimKeepLast?: number;
   orientationMessage?: string;
 }
 
@@ -115,6 +117,7 @@ export async function createBranch(params: BranchParams): Promise<BranchResult> 
     if (params.trim) {
       trimMetrics = await trimJsonl(snapshotJsonlPath, destJsonlPath, {
         threshold: params.trimThreshold,
+        keepLast: params.trimKeepLast,
       });
     } else {
       await fs.copyFile(snapshotJsonlPath, destJsonlPath);

--- a/src/core/trimmer.ts
+++ b/src/core/trimmer.ts
@@ -365,41 +365,45 @@ export async function trimJsonl(
         parsed.content = processContentArray(parsed.content, STUB_THRESHOLD, metrics);
       }
 
-      // Strip orphaned tool_result blocks that reference tool_use IDs from
-      // skipped pre-compaction content. The API requires every tool_result to
-      // have a matching tool_use in the preceding assistant message.
-      if (skippedToolUseIds.size > 0) {
-        for (const key of ['message.content', 'content'] as const) {
-          const content = key === 'message.content' ? parsed.message?.content : parsed.content;
-          if (Array.isArray(content)) {
-            const filtered = content.filter((block: any) => {
-              if (block.type === 'tool_result' && block.tool_use_id && skippedToolUseIds.has(block.tool_use_id)) {
-                return false;
-              }
-              return true;
-            });
-            if (filtered.length !== content.length) {
-              if (key === 'message.content') {
-                parsed.message.content = filtered;
-              } else {
-                parsed.content = filtered;
-              }
-            }
-          }
-        }
-      }
-
       // Strip API usage data — it reflects the original pre-trim context size
       // and would cause the analyzer to report stale (too-high) token counts.
       if (parsed.message?.usage) delete parsed.message.usage;
       if (parsed.usage) delete parsed.usage;
     } else {
       // Entry falls within the last KEEP_LAST emitted entries: still count
-      // tool_use requests for metrics, but leave the entry fully unmodified.
+      // tool_use requests for metrics, but leave the entry's content and
+      // usage metadata fully unmodified.
       for (const content of [parsed.message?.content, parsed.content]) {
         if (Array.isArray(content)) {
           for (const block of content) {
             if (block?.type === 'tool_use') metrics.toolUseRequests++;
+          }
+        }
+      }
+    }
+
+    // Strip orphaned tool_result blocks that reference tool_use IDs from
+    // skipped pre-compaction content. The API requires every tool_result to
+    // have a matching tool_use in the preceding assistant message. This is a
+    // structural fix required for the output to be replayable, so it applies
+    // to entries in the keepLast window too — an orphan there would leave the
+    // file invalid regardless of how recent the entry is.
+    if (skippedToolUseIds.size > 0) {
+      for (const key of ['message.content', 'content'] as const) {
+        const content = key === 'message.content' ? parsed.message?.content : parsed.content;
+        if (Array.isArray(content)) {
+          const filtered = content.filter((block: any) => {
+            if (block.type === 'tool_result' && block.tool_use_id && skippedToolUseIds.has(block.tool_use_id)) {
+              return false;
+            }
+            return true;
+          });
+          if (filtered.length !== content.length) {
+            if (key === 'message.content') {
+              parsed.message.content = filtered;
+            } else {
+              parsed.content = filtered;
+            }
           }
         }
       }

--- a/src/core/trimmer.ts
+++ b/src/core/trimmer.ts
@@ -6,9 +6,22 @@ import * as fs from 'node:fs/promises';
 import type { TrimMetrics } from '../types/index.js';
 
 const DEFAULT_STUB_THRESHOLD = 500;
+const DEFAULT_KEEP_LAST = 20;
 
 export interface TrimOptions {
   threshold?: number;
+  /**
+   * Number of trailing non-empty, non-skipped entries to leave fully untouched:
+   * no tool_result stubbing, no tool_use input stubbing, no image stripping,
+   * no thinking removal, no usage-metadata deletion.
+   *
+   * Structural skipping (pre-compaction, file-history-snapshot,
+   * queue-operation, orphaned tool_result references) still applies — those
+   * entries are dead weight regardless of recency.
+   *
+   * Defaults to DEFAULT_KEEP_LAST. Pass 0 to disable.
+   */
+  keepLast?: number;
 }
 
 /** Tool names known to carry large file-content payloads. */
@@ -180,6 +193,7 @@ export async function trimJsonl(
   options: TrimOptions = {}
 ): Promise<TrimMetrics> {
   const STUB_THRESHOLD = Math.max(options.threshold ?? DEFAULT_STUB_THRESHOLD, 50);
+  const KEEP_LAST = Math.max(options.keepLast ?? DEFAULT_KEEP_LAST, 0);
 
   const metrics: TrimMetrics = {
     originalBytes: 0,
@@ -252,11 +266,50 @@ export async function trimJsonl(
     preStream.destroy();
   }
 
+  // ── Pass 2.5: Count entries that will survive structural skipping ──
+  // An "emitted" entry here matches the surviving-entry rules in Pass 3:
+  // non-empty line, not before the compaction boundary, not
+  // file-history-snapshot, not queue-operation. Unparseable lines are
+  // written through verbatim, so they count too.
+  //
+  // The count lets Pass 3 leave the last KEEP_LAST emitted entries fully
+  // untouched (no stubbing, no image strip, no thinking removal, no usage
+  // metadata deletion).
+  let totalEmittedEntries = 0;
+  if (KEEP_LAST > 0) {
+    const countStream = createReadStream(sourcePath, { encoding: 'utf-8' });
+    const countRl = readline.createInterface({ input: countStream, crlfDelay: Infinity });
+    let countLineNum = 0;
+    for await (const line of countRl) {
+      if (!line.trim()) { countLineNum++; continue; }
+      if (lastCompactionLine >= 0 && countLineNum < lastCompactionLine) {
+        countLineNum++;
+        continue;
+      }
+      // Cheap string check: only JSON.parse if the line might be a skip type.
+      let skipped = false;
+      if (line.includes('file-history-snapshot') || line.includes('queue-operation')) {
+        try {
+          const p = JSON.parse(line);
+          if (p.type === 'file-history-snapshot' || p.type === 'queue-operation') {
+            skipped = true;
+          }
+        } catch { /* not valid JSON — counts as emitted (written verbatim) */ }
+      }
+      if (!skipped) totalEmittedEntries++;
+      countLineNum++;
+    }
+    countRl.close();
+    countStream.destroy();
+  }
+  const keepFromEmitIndex = KEEP_LAST > 0 ? totalEmittedEntries - KEEP_LAST : Number.POSITIVE_INFINITY;
+
   // ── Pass 3: Trim, skipping lines before last compaction boundary ──
   const fileStream = createReadStream(sourcePath, { encoding: 'utf-8' });
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
   const writer = createWriteStream(destPath, { encoding: 'utf-8' });
   let currentLine = 0;
+  let emitIndex = 0; // index among entries that pass structural skipping
 
   for await (const line of rl) {
     if (!line.trim()) { currentLine++; continue; }
@@ -273,6 +326,7 @@ export async function trimJsonl(
       parsed = JSON.parse(line);
     } catch {
       writer.write(line + '\n');
+      emitIndex++;
       currentLine++;
       continue;
     }
@@ -300,44 +354,59 @@ export async function trimJsonl(
       metrics.assistantResponses++;
     }
 
-    // Process content arrays (images, tool results, tool_use inputs, thinking)
-    if (Array.isArray(parsed.message?.content)) {
-      parsed.message.content = processContentArray(parsed.message.content, STUB_THRESHOLD, metrics);
-    }
-    if (Array.isArray(parsed.content)) {
-      parsed.content = processContentArray(parsed.content, STUB_THRESHOLD, metrics);
-    }
+    const inKeepLastWindow = emitIndex >= keepFromEmitIndex;
 
-    // Strip orphaned tool_result blocks that reference tool_use IDs from
-    // skipped pre-compaction content. The API requires every tool_result to
-    // have a matching tool_use in the preceding assistant message.
-    if (skippedToolUseIds.size > 0) {
-      for (const key of ['message.content', 'content'] as const) {
-        const content = key === 'message.content' ? parsed.message?.content : parsed.content;
+    if (!inKeepLastWindow) {
+      // Process content arrays (images, tool results, tool_use inputs, thinking)
+      if (Array.isArray(parsed.message?.content)) {
+        parsed.message.content = processContentArray(parsed.message.content, STUB_THRESHOLD, metrics);
+      }
+      if (Array.isArray(parsed.content)) {
+        parsed.content = processContentArray(parsed.content, STUB_THRESHOLD, metrics);
+      }
+
+      // Strip orphaned tool_result blocks that reference tool_use IDs from
+      // skipped pre-compaction content. The API requires every tool_result to
+      // have a matching tool_use in the preceding assistant message.
+      if (skippedToolUseIds.size > 0) {
+        for (const key of ['message.content', 'content'] as const) {
+          const content = key === 'message.content' ? parsed.message?.content : parsed.content;
+          if (Array.isArray(content)) {
+            const filtered = content.filter((block: any) => {
+              if (block.type === 'tool_result' && block.tool_use_id && skippedToolUseIds.has(block.tool_use_id)) {
+                return false;
+              }
+              return true;
+            });
+            if (filtered.length !== content.length) {
+              if (key === 'message.content') {
+                parsed.message.content = filtered;
+              } else {
+                parsed.content = filtered;
+              }
+            }
+          }
+        }
+      }
+
+      // Strip API usage data — it reflects the original pre-trim context size
+      // and would cause the analyzer to report stale (too-high) token counts.
+      if (parsed.message?.usage) delete parsed.message.usage;
+      if (parsed.usage) delete parsed.usage;
+    } else {
+      // Entry falls within the last KEEP_LAST emitted entries: still count
+      // tool_use requests for metrics, but leave the entry fully unmodified.
+      for (const content of [parsed.message?.content, parsed.content]) {
         if (Array.isArray(content)) {
-          const filtered = content.filter((block: any) => {
-            if (block.type === 'tool_result' && block.tool_use_id && skippedToolUseIds.has(block.tool_use_id)) {
-              return false;
-            }
-            return true;
-          });
-          if (filtered.length !== content.length) {
-            if (key === 'message.content') {
-              parsed.message.content = filtered;
-            } else {
-              parsed.content = filtered;
-            }
+          for (const block of content) {
+            if (block?.type === 'tool_use') metrics.toolUseRequests++;
           }
         }
       }
     }
 
-    // Strip API usage data — it reflects the original pre-trim context size
-    // and would cause the analyzer to report stale (too-high) token counts.
-    if (parsed.message?.usage) delete parsed.message.usage;
-    if (parsed.usage) delete parsed.usage;
-
     writer.write(JSON.stringify(parsed) + '\n');
+    emitIndex++;
     currentLine++;
   }
 

--- a/src/core/trimmer.ts
+++ b/src/core/trimmer.ts
@@ -34,6 +34,12 @@ const PRESERVED_INPUT_FIELDS = new Set([
   'edit_mode',
   'cell_type',
   'cell_id',
+  // Agent/Task dispatch prompt — subagents receive this verbatim as their
+  // instructions. Stubbing it means dispatched agents get
+  // "[Trimmed input: ~N chars]" instead of the real task, which is
+  // catastrophic for subagent behaviour. It is frequently >500 chars so it
+  // trips the broad-fallback without explicit preservation.
+  'prompt',
 ]);
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,12 @@ export interface AutoTrimConfig {
   threshold?: number;
   sizeThresholdBytes?: number;
   maxBackups?: number;
+  /**
+   * Number of trailing non-empty, non-skipped jsonl entries to leave fully
+   * untouched when trimming (no stubbing, no image strip, no thinking
+   * removal, no usage metadata deletion). See TrimOptions.keepLast.
+   */
+  keepLast?: number;
 }
 
 export interface AutoTrimLogEntry {

--- a/tests/trimmer.test.ts
+++ b/tests/trimmer.test.ts
@@ -190,6 +190,31 @@ describe('trimmer', () => {
     });
 
     it('preserves identification fields in broad fallback', async () => {
+      // Use a non-preserved string field (extra) to force a stubbing pass so
+      // the metric increments and we can assert preserved fields come through
+      // untouched.
+      const bigExtra = 'z'.repeat(600);
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'assistant', content: [{
+          type: 'tool_use', id: 't1', name: 'CustomTool',
+          input: { description: 'do stuff', extra: bigExtra }
+        }] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest);
+      const output = await readJsonl(dest);
+
+      expect(metrics.toolUseInputsStubbed).toBe(1);
+      const input = output[0].content[0].input;
+      expect(input.description).toBe('do stuff');
+      expect(input.extra).toContain('[Trimmed input');
+    });
+
+    it('preserves Task/Agent prompt field even when over threshold', async () => {
+      // The Agent/Task tool input's `prompt` field carries the dispatched
+      // subagent's instructions verbatim. Stubbing it would hand the subagent
+      // "[Trimmed input: ~N chars]" instead of a real task.
       const bigPrompt = 'z'.repeat(600);
       const src = await writeJsonl('src.jsonl', [
         { type: 'assistant', content: [{
@@ -202,10 +227,11 @@ describe('trimmer', () => {
       const metrics = await trimJsonl(src, dest);
       const output = await readJsonl(dest);
 
-      expect(metrics.toolUseInputsStubbed).toBe(1);
+      // No non-preserved string field is large enough to stub — metric stays 0.
+      expect(metrics.toolUseInputsStubbed).toBe(0);
       const input = output[0].content[0].input;
       expect(input.description).toBe('do stuff');
-      expect(input.prompt).toContain('[Trimmed input');
+      expect(input.prompt).toBe(bigPrompt);
     });
 
     it('does not stub small tool_use inputs', async () => {

--- a/tests/trimmer.test.ts
+++ b/tests/trimmer.test.ts
@@ -72,7 +72,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.toolResultsStubbed).toBe(1);
@@ -87,7 +87,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.toolResultsStubbed).toBe(0);
@@ -101,7 +101,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.toolResultsStubbed).toBe(1);
@@ -121,7 +121,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.imagesStripped).toBe(1);
@@ -140,7 +140,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.signaturesStripped).toBe(1);
@@ -160,7 +160,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.toolUseInputsStubbed).toBe(1);
@@ -179,7 +179,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.toolUseInputsStubbed).toBe(1);
@@ -202,7 +202,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(metrics.toolUseInputsStubbed).toBe(1);
@@ -224,7 +224,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       // No non-preserved string field is large enough to stub — metric stays 0.
@@ -312,7 +312,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      await trimJsonl(src, dest);
+      await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(output[0].message.usage).toBeUndefined();
@@ -360,11 +360,11 @@ describe('trimmer', () => {
       const dest = path.join(tmpDir, 'dest.jsonl');
 
       // Default threshold (500) should not stub
-      const m1 = await trimJsonl(src, dest);
+      const m1 = await trimJsonl(src, dest, { keepLast: 0 });
       expect(m1.toolResultsStubbed).toBe(0);
 
       // Threshold 200 should stub
-      const m2 = await trimJsonl(src, dest, { threshold: 200 });
+      const m2 = await trimJsonl(src, dest, { threshold: 200, keepLast: 0 });
       expect(m2.toolResultsStubbed).toBe(1);
     });
 
@@ -376,7 +376,7 @@ describe('trimmer', () => {
       const dest = path.join(tmpDir, 'dest.jsonl');
 
       // threshold=10 should be clamped to 50, so 60 chars gets stubbed
-      const metrics = await trimJsonl(src, dest, { threshold: 10 });
+      const metrics = await trimJsonl(src, dest, { threshold: 10, keepLast: 0 });
       expect(metrics.toolResultsStubbed).toBe(1);
     });
   });
@@ -390,7 +390,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      const metrics = await trimJsonl(src, dest);
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
 
       expect(metrics.originalBytes).toBeGreaterThan(0);
       expect(metrics.trimmedBytes).toBeGreaterThan(0);
@@ -443,7 +443,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      await trimJsonl(src, dest);
+      await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       // Should have summary + user + assistant = 3 lines
@@ -471,7 +471,7 @@ describe('trimmer', () => {
       ]);
       const dest = path.join(tmpDir, 'dest.jsonl');
 
-      await trimJsonl(src, dest);
+      await trimJsonl(src, dest, { keepLast: 0 });
       const output = await readJsonl(dest);
 
       expect(output).toHaveLength(2); // summary + message
@@ -530,6 +530,171 @@ describe('trimmer', () => {
       expect(output[1].content[0].text).toBe('The auth module uses JWT with refresh tokens.');
       expect(output[2].content).toBe('what about the API?');
       expect(output[3].content[0].text).toBe('The API uses Express with middleware.');
+    });
+  });
+
+  describe('keepLast option', () => {
+    it('leaves entries within the last N fully unmodified even when over threshold', async () => {
+      const bigResult = 'x'.repeat(600);
+      const bigWriteContent = 'y'.repeat(600);
+      const src = await writeJsonl('src.jsonl', [
+        // Older entries — should be stubbed
+        { type: 'assistant', content: [{ type: 'tool_result', tool_use_id: 't1', content: bigResult }] },
+        { type: 'assistant', content: [{
+          type: 'tool_use', id: 't2', name: 'Write',
+          input: { file_path: '/a/b.ts', content: bigWriteContent }
+        }] },
+        // Trailing entries — within keepLast=2 window, should be untouched
+        { type: 'assistant', content: [{ type: 'tool_result', tool_use_id: 't3', content: bigResult }] },
+        { type: 'assistant', content: [{
+          type: 'tool_use', id: 't4', name: 'Write',
+          input: { file_path: '/c/d.ts', content: bigWriteContent }
+        }] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      await trimJsonl(src, dest, { keepLast: 2 });
+      const output = await readJsonl(dest);
+
+      // First two were outside keepLast window — content stubbed.
+      expect(output[0].content[0].content).toContain('[Trimmed tool result');
+      expect(output[1].content[0].input.content).toContain('[Trimmed input');
+      // Last two were inside keepLast window — untouched.
+      expect(output[2].content[0].content).toBe(bigResult);
+      expect(output[3].content[0].input.content).toBe(bigWriteContent);
+    });
+
+    it('skips thinking removal and image stripping for entries in keepLast window', async () => {
+      const src = await writeJsonl('src.jsonl', [
+        // Older entry — content processing applies.
+        { type: 'assistant', content: [
+          { type: 'thinking', thinking: 'old reasoning', signature: 'sig-old' },
+          { type: 'text', text: 'old response' },
+        ] },
+        // Trailing entry — within keepLast=1, should be untouched.
+        { type: 'assistant', content: [
+          { type: 'thinking', thinking: 'recent reasoning', signature: 'sig-new' },
+          { type: 'tool_result', tool_use_id: 't1', content: [
+            { type: 'image', source: { type: 'base64', data: 'AAAA'.repeat(400) } },
+            { type: 'text', text: 'recent result' },
+          ] },
+        ] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest, { keepLast: 1 });
+      const output = await readJsonl(dest);
+
+      // Older entry: thinking stripped.
+      expect(metrics.signaturesStripped).toBe(1);
+      expect(output[0].content.some((b: any) => b.type === 'thinking')).toBe(false);
+
+      // Recent entry: thinking block kept, image kept.
+      const recent = output[1].content;
+      expect(recent.some((b: any) => b.type === 'thinking')).toBe(true);
+      const toolResult = recent.find((b: any) => b.type === 'tool_result');
+      expect(toolResult.content.some((c: any) => c.type === 'image')).toBe(true);
+      // Metric does not reflect the preserved image.
+      expect(metrics.imagesStripped).toBe(0);
+    });
+
+    it('preserves usage metadata on entries within the keepLast window', async () => {
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'old' }], usage: { input_tokens: 10 } } },
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'recent' }], usage: { input_tokens: 99 } } },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      await trimJsonl(src, dest, { keepLast: 1 });
+      const output = await readJsonl(dest);
+
+      // Older entry: usage stripped.
+      expect(output[0].message.usage).toBeUndefined();
+      // Recent entry: usage kept.
+      expect(output[1].message.usage).toEqual({ input_tokens: 99 });
+    });
+
+    it('keepLast=0 disables the feature (fully stubs like before)', async () => {
+      const bigContent = 'x'.repeat(600);
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'assistant', content: [{ type: 'tool_result', tool_use_id: 't1', content: bigContent }] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest, { keepLast: 0 });
+      const output = await readJsonl(dest);
+
+      expect(metrics.toolResultsStubbed).toBe(1);
+      expect(output[0].content[0].content).toContain('[Trimmed tool result');
+    });
+
+    it('keepLast larger than entry count leaves everything untouched', async () => {
+      const bigContent = 'x'.repeat(600);
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'assistant', content: [{ type: 'tool_result', tool_use_id: 't1', content: bigContent }] },
+        { type: 'assistant', content: [{ type: 'tool_result', tool_use_id: 't2', content: bigContent }] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest, { keepLast: 100 });
+      const output = await readJsonl(dest);
+
+      expect(metrics.toolResultsStubbed).toBe(0);
+      expect(output[0].content[0].content).toBe(bigContent);
+      expect(output[1].content[0].content).toBe(bigContent);
+    });
+
+    it('structural skipping still applies to entries in the keepLast window', async () => {
+      // file-history-snapshot and queue-operation entries should be removed
+      // regardless of recency — they are dead weight.
+      const bigContent = 'x'.repeat(600);
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'user', content: 'old' },
+        { type: 'file-history-snapshot', data: { files: ['a.ts'] } },
+        { type: 'queue-operation', op: 'flush' },
+        { type: 'assistant', content: [{ type: 'tool_result', tool_use_id: 't1', content: bigContent }] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest, { keepLast: 10 });
+      const output = await readJsonl(dest);
+
+      expect(metrics.fileHistoryRemoved).toBe(1);
+      expect(metrics.queueOperationsRemoved).toBe(1);
+      // Remaining entries kept, content preserved (inside keepLast window).
+      expect(output).toHaveLength(2);
+      expect(output[1].content[0].content).toBe(bigContent);
+    });
+
+    it('counts tool_use requests for entries in the keepLast window', async () => {
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'assistant', content: [
+          { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/a.ts' } },
+          { type: 'tool_use', id: 't2', name: 'Read', input: { file_path: '/b.ts' } },
+        ] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest, { keepLast: 10 });
+
+      expect(metrics.toolUseRequests).toBe(2);
+    });
+
+    it('default keepLast preserves recent entries in a typical small session', async () => {
+      // Small synthetic session: with the default keepLast (20), everything
+      // ends up in the window and nothing is stubbed. This documents the
+      // default behaviour.
+      const bigContent = 'x'.repeat(600);
+      const src = await writeJsonl('src.jsonl', [
+        { type: 'assistant', content: [{ type: 'tool_result', tool_use_id: 't1', content: bigContent }] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      const metrics = await trimJsonl(src, dest);
+      const output = await readJsonl(dest);
+
+      expect(metrics.toolResultsStubbed).toBe(0);
+      expect(output[0].content[0].content).toBe(bigContent);
     });
   });
 });

--- a/tests/trimmer.test.ts
+++ b/tests/trimmer.test.ts
@@ -666,6 +666,41 @@ describe('trimmer', () => {
       expect(output[1].content[0].content).toBe(bigContent);
     });
 
+    it('still strips orphaned tool_result blocks in the keepLast window', async () => {
+      // A tool_result whose matching tool_use was skipped by pre-compaction
+      // leaves the file structurally invalid for API replay. This must be
+      // stripped regardless of recency, even when the orphan lands inside
+      // the keepLast window.
+      const src = await writeJsonl('src.jsonl', [
+        // Pre-compaction: tool_use that will be skipped.
+        { type: 'assistant', content: [
+          { type: 'tool_use', id: 'tu_orphan', name: 'Read', input: { file_path: '/a.ts' } },
+        ] },
+        // Compaction boundary.
+        { type: 'summary', summary: 'compacted' },
+        // Post-compaction: a recent entry (inside keepLast window) with
+        // an orphaned tool_result referencing the pre-compaction tool_use.
+        { type: 'user', content: [
+          { type: 'tool_result', tool_use_id: 'tu_orphan', content: 'orphan result' },
+          { type: 'text', text: 'real user text' },
+        ] },
+      ]);
+      const dest = path.join(tmpDir, 'dest.jsonl');
+
+      // keepLast=10 puts the post-compaction user entry inside the window.
+      await trimJsonl(src, dest, { keepLast: 10 });
+      const output = await readJsonl(dest);
+
+      // summary + user = 2
+      expect(output).toHaveLength(2);
+      // The orphaned tool_result was stripped even though the entry was
+      // inside the keepLast window.
+      const userContent = output[1].content;
+      expect(userContent).toHaveLength(1);
+      expect(userContent[0].type).toBe('text');
+      expect(userContent[0].text).toBe('real user text');
+    });
+
     it('counts tool_use requests for entries in the keepLast window', async () => {
       const src = await writeJsonl('src.jsonl', [
         { type: 'assistant', content: [


### PR DESCRIPTION
## Stacked on #8

This PR depends on #8 (`fix(trimmer): preserve prompt field from broad-fallback stubbing`). Until #8 merges, this diff contains #8's commit as well. After #8 merges, rebase will collapse to only this PR's commit.

## Summary

Introduces a `keepLast` trim option (default `20`) that leaves the N most recent non-empty, non-skipped jsonl entries fully unmodified:

- no tool_result stubbing
- no tool_use input stubbing
- no image stripping
- no thinking-block removal
- no usage metadata deletion

Rationale: the broad stubbing passes sanitise older context well, but aggressively rewriting entries from the current/near-current turn tends to confuse replays and subagent dispatches. Leaving the recent tail untouched keeps the working window faithful to what Claude Code wrote, while older bulk context still gets the full space savings.

Structural skipping (pre-compaction, file-history-snapshot, queue-operation, orphaned tool_result stripping) still applies to the keep-last window — those entries are dead weight regardless of recency.

Pass `--keep-last 0` to disable and restore the pre-existing behaviour.

## Changes

- `src/core/trimmer.ts`:
  - `TrimOptions.keepLast` (new), `DEFAULT_KEEP_LAST = 20`.
  - New cheap pre-scan (Pass 2.5) counts entries that will survive structural skipping.
  - Pass 3 skips content-mutation work for entries inside the window (still counts `toolUseRequests`).
- `src/types/index.ts`: `AutoTrimConfig.keepLast`.
- `src/core/branch-manager.ts`: `BranchParams.trimKeepLast` wired through to `trimJsonl`.
- `src/commands/trim.ts`, `src/commands/branch.ts`, `src/commands/auto-trim.ts`: `--keep-last <n>` CLI flag. `auto-trim` also respects `autoTrim.keepLast` in config, with the CLI flag overriding.
- `tests/trimmer.test.ts`:
  - 7 new tests covering the keep-last behaviour (preservation, opt-out, large N, structural skipping, metrics).
  - Updated 13 existing small-fixture tests to pass `{ keepLast: 0 }` so they continue asserting the stubbing/stripping behaviour they were written for.

## Test plan

- [x] `npm run test:run` — 474 passed (up from 465 baseline; +1 from #8, +8 from this PR)
- [x] `npm run build` — clean TypeScript compile
- [x] New tests verify: entries inside the window are preserved verbatim even when content >600 chars; thinking/image preserved; usage metadata preserved; `keepLast=0` reproduces old behaviour; `keepLast > total entries` leaves everything untouched; structural skipping (file-history, queue-op) still applies; `toolUseRequests` counted for window entries.